### PR TITLE
Optimize image recreation by caching pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /subgen
 
 RUN apt-get update && apt-get -y install python3 python3-pip
 
+ADD https://raw.githubusercontent.com/McCloudS/subgen/main/subgen/requirements.txt /subgen/requirements.txt
+
 RUN pip install -r requirements.txt
 
 ENTRYPOINT ["python3"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM ubuntu:latest
 
+WORKDIR /subgen
+
 RUN apt-get update && apt-get -y install python3 python3-pip
 
-ADD https://raw.githubusercontent.com/McCloudS/subgen/main/subgen/subgen.py /subgen/subgen.py
+RUN pip install -r requirements.txt
 
 ENTRYPOINT ["python3"]
 CMD ["/subgen/subgen.py"]

--- a/subgen/requirements.txt
+++ b/subgen/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+stable-ts
+flask
+requests
+faster-whisper


### PR DESCRIPTION
I noticed when iterating through install configs on my machine that the Dockerfile pulled ~4.5GB of dependencies every time the container was restarted. These changes cache the pip dependencies into the image during build instead of at runtime.