### PR TITLE
Update subgen.py

### DIFF
--- a/subgen/subgen.py
+++ b/subgen/subgen.py
@@ -226,7 +226,7 @@ def delete_model():
     if len(files_to_transcribe) == 0:
         global model
         logging.debug("Queue is empty, clearing/releasing VRAM")
-        del model
+        model = None
         gc.collect()
 
 def get_lang_pair(whisper_languages, key):


### PR DESCRIPTION
Set model to none rather than deleting it to avoid raising a NameError exception.

Resolved this exception I was getting:
```
Transcriptions are limited to running 2 at a time
Running 4 threads per transcription
Starting to search folders to see if we need to create subtitles.
/xxx/xxx.mkv already has a subgen created for this, skipping it

Traceback (most recent call last):
  File "/subgen/./subgen.py", line 416, in <module>
    transcribe_existing()
  File "/subgen/./subgen.py", line 410, in transcribe_existing
    gen_subtitles(path_mapping(file_path), transcribe_or_translate, False)
  File "/subgen/./subgen.py", line 296, in gen_subtitles
    delete_model()
  File "/subgen/./subgen.py", line 229, in delete_model
    del model
NameError: name 'model' is not defined
```