### PR TITLE
Fix container startup failure due to CMD path error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ ENV PYTHONUNBUFFERED 1
 
 ADD https://raw.githubusercontent.com/McCloudS/subgen/main/subgen/subgen.py /subgen/subgen.py
 
-CMD [ "python3", "-u", "./subgen.py" ]
+CMD [ "python3", "-u", "subgen/subgen.py" ]
 
 EXPOSE 8090

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -8,6 +8,6 @@ ENV PYTHONUNBUFFERED 1
 
 ADD https://raw.githubusercontent.com/McCloudS/subgen/main/subgen/subgen.py /subgen/subgen.py
 
-CMD [ "python3", "-u", "./subgen.py" ]
+CMD [ "python3", "-u", "subgen/subgen.py" ]
 
 EXPOSE 8090


### PR DESCRIPTION
Just something that was giving me issues in running this, both from the image and building my own image. 

i was getting error "/subgen/./subgen.py no such file or directory"
changing this to "/subgen/subgen.py" fixed it.