### PR TITLE
Patch: fix "language_code" in /detect-language endpoint

### DIFF
--- a/subgen.py
+++ b/subgen.py
@@ -28,6 +28,10 @@ from watchdog.observers.polling import PollingObserver as Observer
 from watchdog.events import FileSystemEventHandler
 import faster_whisper
 
+def get_key_by_value(d, value):
+    reverse_dict = {v: k for k, v in d.items()}
+    return reverse_dict.get(value)
+
 def convert_to_bool(in_bool):
     # Convert the input to string and lower case, then check against true values
     return str(in_bool).lower() in ('true', 'on', '1', 'y', 'yes')
@@ -466,7 +470,8 @@ def detect_language(
         audio_file: UploadFile = File(...),
         #encode: bool = Query(default=True, description="Encode audio first through ffmpeg") # This is always false from Bazarr
 ):    
-    detected_lang_code = ""  # Initialize with an empty string
+    detected_language = ""  # Initialize with an empty string
+    language_code = ""  # Initialize with an empty string
     if int(detect_language_length) != 30:
         logging.info(f"Detect language is set to detect on the first {detect_language_length} seconds of the audio.")
     try:
@@ -477,8 +482,10 @@ def detect_language(
         task_queue.put(task_id)
         
         audio_data = np.frombuffer(audio_file.file.read(), np.int16).flatten().astype(np.float32) / 32768.0
-        detected_lang_code = model.transcribe_stable(whisper.pad_or_trim(audio_data, int(detect_language_length) * 16000), input_sr=16000).language
-            
+        detected_language = model.transcribe_stable(whisper.pad_or_trim(audio_data, int(detect_language_length) * 16000), input_sr=16000).language
+        # reverse lookup of language -> code, ex: "english" -> "en", "nynorsk" -> "nn", ...
+        language_code = get_key_by_value(whisper_languages, detected_language)
+
     except Exception as e:
         logging.info(f"Error processing or transcribing Bazarr {audio_file.filename}: {e}")
         
@@ -486,7 +493,7 @@ def detect_language(
         task_queue.task_done()
         delete_model()
 
-        return {"detected_language": whisper_languages.get(detected_lang_code, detected_lang_code) , "language_code": detected_lang_code}
+        return {"detected_language": detected_language, "language_code": language_code}
 
 def start_model():
     global model


### PR DESCRIPTION
First off, thanks for this great tool @McCloudS !  Came across this project over the weekend, and it was super easy to wire into my setup at home.  I'm using the bazarr + plex + tautulli bits for integrations.


This PR is a patch for the `/detect-language` POST endpoint's response.

It prevents Bazarr from throttling whisperai (subgen) provider for 10 minutes with `LanguageReverseError`

CHANGED: 
- "language_code" -> two letter language code (changed)

UNCHANGED:
- "detected_language" -> full language name, e.g. "english" or "nynorsk" (unchanged)

```
Responses before:
{"detected_language":"chinese","language_code":"chinese"}
{"detected_language":"english","language_code":"english"}
{"detected_language":"nynorsk","language_code":"nynorsk"}
{"detected_language":"swedish","language_code":"swedish"}
{"detected_language":"welsh","language_code":"welsh"}

Responses after:
{"detected_language":"chinese","language_code":"zh"}
{"detected_language":"english","language_code":"en"}
{"detected_language":"nynorsk","language_code":"nn"}
{"detected_language":"swedish","language_code":"sv"}
{"detected_language":"welsh","language_code":"cy"}
```


Background:
I have a huge queue of items in bazarr, and I've been using subgen to generate all of the subtitles over the past few days.  in Bazarr, I kept getting intermittent `LanguageReverseError`s when using subgen as the whisperai provider.  Every time it hit that, Bazarr would throttle the `whisperai` provider for 10 minutes.  

Since `whisperai` is my only real provider in use, all the remaining items in the queue would blow through and the search task would complete as fast as bazarr could read the queue and say it finished processing the item (with no providers left available, the search for the queued item happens, returning 0 results without error).

Each night the task would run it would only process a few to a few dozen items before crashing out.  With a "Wanted" list of > 18000 items, the past few days hadn't made much of dent at all in that list.

I initially thought it was something to do with the `nynorsk` language in bazarr since that was the language in the log that preceded every `LanguageReverseError` stack trace in the bazarr logs.  Eventually I saw a couple others (malay, khmer) as well, and that got me looking into it.

Here's what I traced:

Bazarr uses both the `"language_code"` and the `"detected_language"` from the response:
https://github.com/morpheus65535/bazarr/blob/5429749e72bcbcd960e63704bfac522bd87cc244/libs/subliminal_patch/providers/whisperai.py#L259C1-L259C94

It first tries to match the language from the `"language_code"`, expecting a two-letter code:
https://github.com/morpheus65535/bazarr/blob/5429749e72bcbcd960e63704bfac522bd87cc244/libs/subliminal_patch/providers/whisperai.py#L160-L161

When that fails, it tries to match the language by name:
https://github.com/morpheus65535/bazarr/blob/5429749e72bcbcd960e63704bfac522bd87cc244/libs/subliminal_patch/providers/whisperai.py#L162-L163

For many languages with simple names, that worked: `"english"`, `"french"`, `"german"`, etc...
For languages that didn't map exactly, the final `Language.fromname(name)` would raise the `LanguageReverseError` that throttle the provider for 10 min

For the `"nynorsk"` example, the name that it was trying to match was not "nynorsk" but instead something like `"Norwegian Nynorsk"`:
https://github.com/morpheus65535/bazarr/blob/5429749e72bcbcd960e63704bfac522bd87cc244/libs/babelfish/data/iso-639-3.tab#L4748


I patched my local Bazarr yesterday with a workaround to do this reverse lookup and that fixed the throttling issue to get my queue processing all day yesterday.  This PR should fix the root of the issue I've been experiencing without needing that workaround in bazarr.

