### PR TITLE
Fix subtitle checking logic to properly separate internal vs external subtitle detection

### DIFF
--- a/subgen.py
+++ b/subgen.py
@@ -1136,7 +1136,7 @@ def should_skip_file(file_path: str, target_language: LanguageCode) -> bool:
         return True
 
     # 4. Skip if an internal subtitle exists in skipifinternalsublang language.
-    if skipifinternalsublang and has_subtitle_language(file_path, skipifinternalsublang):
+    if skipifinternalsublang and has_subtitle_language_in_file(file_path, skipifinternalsublang):
         lang_name = skipifinternalsublang.to_name()
         logging.info(f"Skipping {base_name}: Internal subtitles in {lang_name} already exist.")
         return True
@@ -1144,7 +1144,7 @@ def should_skip_file(file_path: str, target_language: LanguageCode) -> bool:
     # 5. Skip if an external subtitle exists in the namesublang language
     if skipifexternalsub and namesublang and LanguageCode.is_valid_language(namesublang):
         external_lang = LanguageCode.from_string(namesublang)
-        if has_subtitle_language(file_path, external_lang):
+        if has_subtitle_of_language_in_folder(file_path, external_lang):
             lang_name = external_lang.to_name()
             logging.info(f"Skipping {base_name}: External subtitles in {lang_name} already exist.")
             return True


### PR DESCRIPTION
# Pull Request Summary

## Fix subtitle checking logic to properly separate internal vs external subtitle detection

### Problem
The subtitle skip logic in `should_skip_file()` was incorrectly using `has_subtitle_language()` for both internal and external subtitle checks. This function checks BOTH internal (embedded) and external (file-based) subtitles, causing logic conflicts when users configured:

- `SKIPIFINTERNALSUBLANG='xy'` - Skip if internal subtitles exist in language 'xy'
- `NAMESUBLANG='en'` - Target language is 'en' 
- `SKIPIFEXTERNALSUB=True` - Skip if external subtitles exist
- `SKIP_IF_TO_TRANSCRIBE_SUB_ALREADY_EXIST=False` - Don't skip based on target language subtitles

The goal was to "still generate subtitles when there are internal subtitles but also skip if there are external subtitles", but the current logic would skip in both cases.

### Solution
**Line 1139**: Changed `has_subtitle_language()` to `has_subtitle_language_in_file()`
- For `SKIPIFINTERNALSUBLANG` check - now only checks internal/embedded subtitles
- Comment already stated "Skip if an **internal** subtitle exists" but code was checking both

**Line 1148**: Changed `has_subtitle_language()` to `has_subtitle_of_language_in_folder()`
- For `SKIPIFEXTERNALSUB` check - now only checks external subtitle files in folder
- Properly implements the external subtitle skip logic

### Technical Details
- `has_subtitle_language()` = checks internal AND external subtitles
- `has_subtitle_language_in_file()` = checks ONLY internal/embedded subtitles  
- `has_subtitle_of_language_in_folder()` = checks ONLY external subtitle files

### Impact
This fix ensures proper separation of internal vs external subtitle detection, allowing users to:
1. Skip processing when internal subtitles exist in a specific language (`SKIPIFINTERNALSUBLANG`)
2. Skip processing when external subtitle files exist (`SKIPIFEXTERNALSUB`)
3. Continue processing when only internal subtitles exist but external files don't

### Files Changed
- `subgen.py`: 2 lines modified in `should_skip_file()` function

### Commit
```
1b88d39 - Fix subtitle checking logic to properly separate internal vs external subtitle detection
```