### PR TITLE
Fix double task_done in ASR/detect-language handlers

### DIFF
--- a/subgen.py
+++ b/subgen.py
@@ -586,8 +586,7 @@ async def asr(
     
     finally:
         await audio_file.close()
-        task_queue.task_done()
-        ()
+        delete_model()
     
     if result:
         return StreamingResponse(
@@ -666,7 +665,6 @@ async def detect_language(
         
     finally:
         #await audio_file.close()
-        task_queue.task_done()
         delete_model()
 
         return {"detected_language": detected_language.to_name(), "language_code": language_code}
@@ -1142,6 +1140,7 @@ def find_language_audio_track(audio_tracks, find_languages):
             if track['language'] == language:
                 return language
     return None
+
 def find_default_audio_track_language(audio_tracks):    
     """
     Finds the language of the default audio track in the given list of audio tracks.
@@ -1258,6 +1257,7 @@ def should_skip_file(file_path: str, target_language: LanguageCode) -> bool:
     logging.debug(f"Processing {base_name}: No skip conditions met.")
     return False
     
+
 def get_subtitle_languages(video_path):
     """
     Extract language codes from each audio stream in the video file using pyav.


### PR DESCRIPTION
## Summary
- remove extra `task_queue.task_done()` calls from the `/asr` and `/detect-language` HTTP handlers

## Context
When Bazarr hits these endpoints, they enqueue a `Bazarr-*` task that is already consumed by the worker thread, which calls `task_done()` for that queue item. The handlers were calling `task_done()` again, causing `ValueError: task_done() called too many times` and 500s.

## Testing
- not run (local Docker logs show 500s go away with this change)
