### PR TITLE
Set output filename to match output language

### DIFF
--- a/subgen.py
+++ b/subgen.py
@@ -1311,8 +1311,6 @@ def gen_subtitles(file_path: str, transcription_type: str, force_language: Langu
         if is_audio_file and lrc_for_audio_files:
             write_lrc(result, file_name + '.lrc')
         else:
-            if not force_language: 
-                force_language = LanguageCode.from_string(result.language)
             output_language = LanguageCode.from_string(result.language)
             result.to_srt_vtt(name_subtitle(file_path, output_language), word_level=word_level_highlight)
 


### PR DESCRIPTION
In a transcription workflow, the forced language and the output language are always the same.  However in a translate workflow, the forced language will be the input language, which is not the same as the output language.  The current behavior of this line is to generate English subtitles with a filename that reflects the original language.  This PR changes that so that the output filename always matches the output language of the file.