### PR TITLE
fix: compensate for audio start_time offset in container files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 <details>
 <summary><strong>Updates:</strong></summary>
 
+11 Apr 2026: Fixed subtitle timing on files with audio stream offsets (common in Amazon WEB-DL). Whisper ignores silence padding, causing subtitles to be early by the offset amount. Subgen now detects this via ffprobe and compensates automatically when the source video file is accessible. See [Audio Start-Time Offset Fix](#-audio-start-time-offset-fix) for details.
+
 27 Mar 2026: Potentially added ROCm support for AMD GPU/APUs. I don't have anything to test it, so a fair chance it doesn't work at all.  I'm unsure if it will work with AMD APUs.  Image is: `mccloud/subgen:amd`.  It's pretty large right now at ~10gb. In theory, it should see your AMD card the same way it sees any other cuda device. Some light research shows ROCm only 'officially' supports higher end consumer cards and datacenter cards. `HSA_OVERRIDE_GFX_VERSION` can be set to 'trick' your old cards (and maybe APUs) to work, but you'll have to do your own research/googling. 
 
 17 Mar 2026: Added `WEBHOOK_URL_COMPLETED`. When a task finishes, Subgen will send a POST request with a JSON structure.
@@ -122,6 +124,29 @@ If you just want to plug Subgen into Bazarr and get going, here is the absolute 
 Subgen already produces accurately timed subtitles. If you have Bazarr's **Automatic Subtitles Audio Synchronization** enabled, you must exclude `whisperai` from it — otherwise Bazarr will run ffsubsync on top of already-synced subtitles and degrade their quality.
 * In Bazarr, go to **Settings > Subtitles > Audio Synchronization**.
 * Under **"Do not sync subtitles downloaded from those providers"**, add **`whisperai`**.
+
+---
+
+## 🔧 Audio Start-Time Offset Fix
+
+Some media containers — particularly Amazon WEB-DL files — have an audio stream that starts later than the video stream (e.g., audio `start_time` of ~4 seconds). When Bazarr extracts audio from these files, it compensates by prepending silence via ffmpeg's `adelay` filter. However, Whisper's speech recognition completely ignores this digital silence, producing timestamps that are early by the offset amount (e.g., every subtitle appears ~4 seconds too early).
+
+Subgen now automatically detects and compensates for this. When the source video file is accessible, it uses `ffprobe` to read the audio stream's `start_time` metadata, then shifts all Whisper timestamps forward by that amount after transcription.
+
+**This fix is fully backwards compatible.** If the video file is not accessible, or has no audio offset (i.e. `start_time` is 0), behaviour is completely unchanged.
+
+### How to enable it (Bazarr)
+
+1. **Mount your media into the Subgen container** with the same paths that Bazarr sees. For example, if Bazarr sees TV shows at `/tv`, add a volume mount so Subgen also sees `/tv`:
+   ```yaml
+   volumes:
+     - /path/to/your/tv:/tv
+     - /path/to/your/movies:/movies
+   ```
+
+2. **Enable "Pass Video Name" in Bazarr.** Go to **Settings > Whisper Provider** and check the **Pass Video Name** option. This tells Bazarr to send the video file path alongside the audio, allowing Subgen to look up the source file and detect any audio offset.
+
+That's it. No new environment variables are required. Files without an audio offset are unaffected.
 
 ---
 

--- a/subgen.py
+++ b/subgen.py
@@ -47,6 +47,7 @@ from datetime import datetime
 from threading import Lock, Event, Timer
 import os
 import json
+import subprocess
 import xml.etree.ElementTree as ET
 import threading
 import sys
@@ -832,6 +833,72 @@ async def asr(
 # ASR WORKER FUNCTION
 # ============================================================================
 
+def get_audio_start_time(video_path: str) -> float:
+    """
+    Use ffprobe to detect the audio stream start_time offset from a video file.
+    
+    Some containers (especially Amazon WEB-DL) have audio streams that start
+    later than the video stream. Bazarr compensates with adelay silence padding,
+    but Whisper ignores digital silence, causing all timestamps to be early by
+    the start_time offset.
+    
+    Returns the audio start_time in seconds, or 0.0 if not detectable.
+    """
+    if not video_path or not os.path.isfile(video_path):
+        return 0.0
+    
+    try:
+        result = subprocess.run(
+            ['ffprobe', '-v', 'error', '-select_streams', 'a:0',
+             '-show_entries', 'stream=start_time',
+             '-of', 'json', video_path],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode != 0:
+            return 0.0
+        
+        data = json.loads(result.stdout)
+        streams = data.get('streams', [])
+        if streams:
+            start_time = float(streams[0].get('start_time', 0))
+            if start_time > 0.1:  # only apply for significant offsets
+                logging.info(f"Detected audio start_time offset: {start_time:.3f}s for {os.path.basename(video_path)}")
+                return start_time
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, ValueError, OSError) as e:
+        logging.debug(f"Could not detect audio start_time for {video_path}: {e}")
+    
+    return 0.0
+
+
+def apply_timestamp_offset(result, offset: float) -> None:
+    """
+    Shift all segment and word timestamps forward by the given offset.
+    
+    This compensates for audio start_time offsets in containers where the
+    audio stream starts later than the video stream. Whisper produces
+    timestamps relative to the audio stream start, but subtitles need
+    to be aligned to the video/container timeline.
+    
+    Note: Segment.start/end are properties that delegate to the first/last
+    word timestamps, so we only need to shift word timestamps to avoid
+    double-application. For segments without words, we shift _default_start/end.
+    """
+    if offset <= 0:
+        return
+    
+    for segment in result.segments:
+        if hasattr(segment, 'words') and segment.words:
+            for word in segment.words:
+                word.start += offset
+                word.end += offset
+        else:
+            # Segments without words use _default_start/_default_end
+            segment._default_start += offset
+            segment._default_end += offset
+    
+    logging.info(f"Applied +{offset:.3f}s timestamp offset to {len(result.segments)} segments")
+
+
 def asr_task_worker(task_data: dict) -> None:
     """
     Worker function that processes ASR tasks from the queue. 
@@ -867,8 +934,18 @@ def asr_task_worker(task_data: dict) -> None:
 
         args.update(kwargs)
         
+        # Detect audio start_time offset from source file (if accessible)
+        audio_offset = get_audio_start_time(video_file) if video_file else 0.0
+        
         # Perform transcription
         result = model.transcribe(task=task, language=language, **args, verbose=None)
+        
+        # Apply audio start_time offset to compensate for container timing
+        # Whisper ignores silence padding (adelay) from Bazarr, so timestamps
+        # are relative to audio stream start, not container start
+        if audio_offset > 0:
+            apply_timestamp_offset(result, audio_offset)
+        
         appendLine(result)
         
         # Set result for blocking endpoint


### PR DESCRIPTION
## Summary

- Fixes subtitle timing on media files where the audio stream has a non-zero `start_time` (common in Amazon WEB-DL). Whisper ignores the silence padding that Bazarr prepends via `adelay`, causing all subtitles to be early by the offset amount (~4s on affected files).
- Subgen now uses `ffprobe` to detect the audio stream's `start_time` from the source video file and shifts Whisper timestamps forward after transcription.
- Fully backwards compatible — when the video file isn't mounted or has no offset, behaviour is completely unchanged.

## Problem

Some containers (especially Amazon WEB-DL) have an audio stream that starts later than the video stream (e.g., `start_time=4.087`). When Bazarr extracts audio, it compensates with ffmpeg's `adelay` filter to prepend silence. However, Whisper's mel spectrogram + attention mechanism completely ignores digital silence, producing timestamps as if the padding didn't exist. The result: every subtitle appears ~4 seconds too early.

## Solution

Two new functions in `subgen.py`:

1. **`get_audio_start_time(video_path)`** — runs `ffprobe` to read the first audio stream's `start_time`. Returns `0.0` on any failure (file not found, ffprobe error, timeout, no significant offset).

2. **`apply_timestamp_offset(result, offset)`** — shifts word-level timestamps forward by the offset amount. Only shifts word timestamps (not segment `.start`/`.end` which are properties delegating to words) to avoid double-application.

Integration is 3 lines in `asr_task_worker`: detect before transcription, apply after.

## Requirements for users

1. Mount media volumes into the Subgen container with the same paths Bazarr sees
2. Enable **"Pass Video Name"** in Bazarr's Whisper Provider settings

No new environment variables. Files without an audio offset are unaffected.

## Test results (Amazon WEB-DL, audio `start_time=4.087s`)

| Line | Official SRT | Before fix | After fix |
|------|-------------|-----------|----------|
| "Never better" | 21.855s | 17.700s (-4.155s) | 21.787s (-0.068s) |
| "bye-bye time" | 23.064s | 18.960s (-4.104s) | 23.047s (-0.017s) |
| "memory lane" | 24.899s | 20.960s (-3.939s) | 25.047s (+0.148s) |
| "where's Evans" | 27.110s | 22.760s (-4.350s) | 26.847s (-0.263s) |
| "family room" | 28.528s | 24.420s (-4.108s) | 28.507s (-0.021s) |

Files with `start_time=0` produce identical output to before.