### PR TITLE
Fix permissions for ROCm

### DIFF
--- a/Dockerfile.AMD
+++ b/Dockerfile.AMD
@@ -1,4 +1,4 @@
-FROM ghcr.io/jordimas/ctranslate2:latest-ubuntu22.04-rocm7.2
+FROM ghcr.io/opennmt/ctranslate2:latest-ubuntu22.04-rocm7.2
 
 COPY entrypoint.sh /
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,5 +45,14 @@ echo "Fixing permissions on /cache..."
 chown -R "$PUID":"$PGID" /cache
 chown -R "$PUID":"$PGID" /tmp 2>/dev/null || true
 
+# fix group for dri devices
+if [ -e "/dev/dri/renderD128" ]; then
+  echo "Adding group for /dev/dri/renderD128"
+  GID=`stat -c "%g" /dev/dri/renderD128`
+  groupadd -g $GID render2
+  GROUP=`getent group $GID | cut -d: -f1`
+  usermod -aG $GROUP subgen
+fi
+
 echo "Dropping root privileges and starting application..."
-exec gosu "$PUID":"$PGID" "$@"
+exec gosu "$PUID" "$@"

--- a/subgen.py
+++ b/subgen.py
@@ -410,14 +410,6 @@ def transcription_worker():
                         logging.debug(f"Transcription already queued/processing for: {next_task['path']}")
                         
                 delete_model()
-         
-# Force ROCm/HIP context initialization on the main thread first for AMD GPUs
-if transcribe_device == "cuda" and getattr(torch.version, 'hip', None) is not None:
-    try:
-        logging.info("AMD ROCm detected: Initializing model on main thread to establish HIP context...")
-        start_model()
-    except Exception as e:
-        logging.error(f"Failed to initialize ROCm on main thread: {e}")
 
 # Create worker threads
 for _ in range(concurrent_transcriptions):


### PR DESCRIPTION
This pull request allows running on ROCm. The main change is in entrypoint.sh, which adds the subgen user to the correct group of the dri device. This is necessary because gosu does not work with the group_add option of docker. Also, it changes the gosu invocation to only specify the user and not the group, to allow it to also use the secondary groups (see https://github.com/tianon/gosu/issues/33).

Otherwise, it changes the base image to the official channel of ctranslate2, and reverts the unnecessary attempt to pre-load the model, which was not working anyway since start_model is not declared yet.

Fixes #308