### PR TITLE
Improve skip log message when audio language is undetectable

### DIFF
--- a/subgen.py
+++ b/subgen.py
@@ -1792,8 +1792,11 @@ def should_skip_file(file_path: str, target_language: LanguageCode, audio_langs=
     # 4. Skip if a subtitle already exists in the target language.
     if skip_if_target_subtitle_exists:
         if subtitle_exists_in_language(file_path, target_language):
-            lang_name = target_language.to_name()
-            logging.info(f"Skipping {base_name}: Subtitles already exist in {lang_name}.")
+            if target_language == LanguageCode.NONE:
+                logging.info(f"Skipping {base_name}: Subtitles already exist and audio language could not be detected from file metadata.")
+            else:
+                lang_name = target_language.to_name()
+                logging.info(f"Skipping {base_name}: Subtitles already exist in {lang_name}.")
             return True
 
         # Since SUBTITLE_LANGUAGE_NAME overrides the output filename, check if it exists in the folder.

--- a/subgen.py
+++ b/subgen.py
@@ -1,4 +1,4 @@
-subgen_version = '2026.05.2'
+subgen_version = '2026.05.3'
 
 """
 ENVIRONMENT VARIABLES DOCUMENTATION


### PR DESCRIPTION
## Summary

- When a media file has no language tag on its audio tracks, `choose_transcribe_language()` returns `LanguageCode.NONE` and `to_name()` returns Python's `None` object
- This produced the confusing log line: `Skipping Rhoda - S02E04.mp4: Subtitles already exist in None.`
- Now emits a clear, human-readable message: `Skipping Rhoda - S02E04.mp4: Subtitles already exist and audio language could not be detected from file metadata.`

## What changed

`should_skip_file()` in `subgen.py` — the check-4 skip path now branches on `LanguageCode.NONE` before formatting the language name, avoiding the confusing `None` string.

Files with a detected language are unaffected and continue logging `Subtitles already exist in English.` etc.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)