### PR TITLE
Add git pre-commit hook to auto-bump subgen_version

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Auto-bump the patch version in subgen.py whenever it is staged for commit.
+set -euo pipefail
+
+if ! git diff --cached --name-only | grep -q '^subgen\.py$'; then
+  exit 0
+fi
+
+current=$(sed -n "s/.*subgen_version = '\([^']*\)'.*/\1/p" subgen.py)
+if [ -z "$current" ]; then
+  echo "pre-commit: could not read subgen_version — skipping auto-bump" >&2
+  exit 0
+fi
+
+major=$(echo "$current" | cut -d. -f1)
+minor=$(echo "$current" | cut -d. -f2)
+patch=$(echo "$current" | cut -d. -f3)
+new_version="$major.$minor.$((patch + 1))"
+
+sed -i '' "s/subgen_version = '$current'/subgen_version = '$new_version'/" subgen.py
+git add subgen.py
+echo "pre-commit: bumped subgen_version $current → $new_version"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,10 +12,17 @@ if [ -z "$current" ]; then
   exit 0
 fi
 
-major=$(echo "$current" | cut -d. -f1)
-minor=$(echo "$current" | cut -d. -f2)
-patch=$(echo "$current" | cut -d. -f3)
-new_version="$major.$minor.$((patch + 1))"
+year_now=$(date +%Y)
+month_now=$(date +%m)
+year_cur=$(echo "$current" | cut -d. -f1)
+month_cur=$(echo "$current" | cut -d. -f2)
+patch_cur=$(echo "$current" | cut -d. -f3)
+
+if [ "$year_now" = "$year_cur" ] && [ "$month_now" = "$month_cur" ]; then
+  new_version="$year_now.$month_now.$((patch_cur + 1))"
+else
+  new_version="$year_now.$month_now.1"
+fi
 
 sed -i '' "s/subgen_version = '$current'/subgen_version = '$new_version'/" subgen.py
 git add subgen.py


### PR DESCRIPTION
## Summary

- Adds `.githooks/pre-commit` — a shell script that automatically increments the patch version in `subgen_version` whenever `subgen.py` is staged for a commit
- Works correctly in all contexts: main checkout, git worktrees, any tool (Claude Code, command line, IDE)
- The existing Claude Code hook in `.claude/settings.json` had a worktree blind spot: it ran `git diff --cached` from the main project directory, so it never saw staged files inside a worktree

## Activation (one-time per clone)

```bash
git config core.hooksPath .githooks
```

## How it works

1. Checks if `subgen.py` is in the staged file list
2. Reads the current `subgen_version` from the file
3. Increments the patch component (`YYYY.MM.N` → `YYYY.MM.N+1`)
4. Rewrites the version in `subgen.py` and re-stages it before the commit lands

🤖 Generated with [Claude Code](https://claude.ai/claude-code)