### PR TITLE
Fix AMD Dockerfile torch install failing with msgpack memoryview error

### DIFF
--- a/Dockerfile.AMD
+++ b/Dockerfile.AMD
@@ -102,8 +102,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     rm $CTRANSLATE2_ROOT/*.whl
 
 # torch nightly with rocm7.2 — own layer so app dep changes don't re-download torch
-RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install -U --pre \
+RUN python3 -m pip install --no-cache-dir -U --pre \
         torch torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2
 
 # Application Python deps — merged into one layer


### PR DESCRIPTION
## Summary

The AMD Dockerfile build was failing with:

```
ValueError: Memoryview is too large
```

## Root cause

The torch install step used `--mount=type=cache,target=/root/.cache/pip`, which tells pip to write the downloaded wheel to its cache. PyTorch ROCm nightly wheels are 5–10 GB, and pip's vendored msgpack (pure-Python fallback) has a hard 2 GB memoryview limit — exceeded when serializing the wheel into the cache.

## Fix

Replace the cache mount with `--no-cache-dir` on that step. The pip cache wasn't useful here anyway since nightly builds change frequently and won't be reused across builds.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)