### PR TITLE
Fix AMD container missing onnxruntime for VAD support

### DIFF
--- a/Dockerfile.AMD
+++ b/Dockerfile.AMD
@@ -110,6 +110,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install -U \
         numpy fastapi requests uvicorn python-multipart ffmpeg-python \
         watchdog tqdm more-itertools transformers tokenizers huggingface-hub av scipy \
+        onnxruntime \
     && python3 -m pip install -U --no-deps faster-whisper stable-ts-whisperless
 
 # Application files


### PR DESCRIPTION
## Summary

Adds `onnxruntime` to the explicit pip install list in `Dockerfile.AMD`.

## Root cause

`faster-whisper` is installed with `--no-deps` in the AMD image to prevent pip from replacing the custom ROCm-built `ctranslate2` wheel with a CPU-only one from PyPI. That flag also skips `onnxruntime`, which is a `faster-whisper` dependency needed for the VAD filter. The CPU image installs from `requirements.txt` without `--no-deps`, so `onnxruntime` arrives as a transitive dependency there — explaining why the CPU image works fine.

## Fix

One line added to the existing pip install block:

```dockerfile
onnxruntime \
```

VAD runs on CPU regardless of GPU backend, so the standard CPU `onnxruntime` wheel is correct here.

Fixes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)