### PR TITLE
Fix forced subtitle tracks incorrectly treated as full subtitle coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 <details>
 <summary><strong>Updates:</strong></summary>
 
+7 Jun 2026: Fixed a bug where files containing only a **forced** embedded subtitle track were incorrectly treated as having full subtitle coverage and skipped. Forced tracks cover only a small fraction of dialogue (typically foreign-language inserts) and should not count as full coverage. Added `IGNORE_FORCED_SUBTITLES` (default `True`) to control this behaviour.
+
 11 Apr 2026: Fixed subtitle timing on files with audio stream offsets (common in Amazon WEB-DL). Whisper ignores silence padding, causing subtitles to be early by the offset amount. Subgen now detects this via ffprobe and compensates automatically when the source video file is accessible. See [Audio Start-Time Offset Fix](#-audio-start-time-offset-fix) for details.
 
 27 Mar 2026: Potentially added ROCm support for AMD GPU/APUs. I don't have anything to test it, so a fair chance it doesn't work at all.  I'm unsure if it will work with AMD APUs.  Image is: `mccloud/subgen:amd`.  It's pretty large right now at ~10gb. In theory, it should see your AMD card the same way it sees any other cuda device. Some light research shows ROCm only 'officially' supports higher end consumer cards and datacenter cards. `HSA_OVERRIDE_GFX_VERSION` can be set to 'trick' your old cards (and maybe APUs) to work, but you'll have to do your own research/googling. 
@@ -264,6 +266,7 @@ Create two separate Webhooks in Tautulli pointing to `http://<your-ip>:9000/taut
 | `SKIP_UNKNOWN_LANGUAGE` | `False` | Skip processing if Whisper cannot detect the audio language. |
 | `SKIP_ONLY_SUBGEN_SUBTITLES` | `False` | Skips generation only if the file has "subgen" somewhere in the existing subtitle filename. |
 | `SKIP_IF_NO_LANGUAGE_BUT_SUBTITLES_EXIST`| `False` | Skips generation if file doesn't have an audio stream marked with a language, but subtitles exist. |
+| `IGNORE_FORCED_SUBTITLES` | `True` | When `True`, forced embedded subtitle tracks are excluded from all skip-coverage checks. A file whose only matching subtitle tracks are forced will be treated as having no coverage and transcribed normally. Set to `False` to count forced tracks as full coverage (old behaviour). |
 
 ### 📝 Subtitle Formatting & Preferences
 | Variable | Default | Description |

--- a/subgen.py
+++ b/subgen.py
@@ -177,6 +177,7 @@ subtitle_language_naming_type = os.getenv('SUBTITLE_LANGUAGE_NAMING_TYPE', 'ISO_
 only_match_subgen_subtitles = get_env_with_fallback('SKIP_ONLY_SUBGEN_SUBTITLES', 'ONLY_SKIP_IF_SUBGEN_SUBTITLE', False, convert_to_bool)
 skip_unknown_language = convert_to_bool(os.getenv('SKIP_UNKNOWN_LANGUAGE', False))
 skip_if_no_audio_language_but_subtitles_exist = get_env_with_fallback('SKIP_IF_NO_LANGUAGE_BUT_SUBTITLES_EXIST', 'SKIP_IF_LANGUAGE_IS_NOT_SET_BUT_SUBTITLES_EXIST', False, convert_to_bool)
+ignore_forced_subtitles = convert_to_bool(os.getenv('IGNORE_FORCED_SUBTITLES', True))
 should_whisper_detect_audio_language = convert_to_bool(os.getenv('SHOULD_WHISPER_DETECT_AUDIO_LANGUAGE', False))
 show_in_subname_subgen = convert_to_bool(os.getenv('SHOW_IN_SUBNAME_SUBGEN', True))
 show_in_subname_model = convert_to_bool(os.getenv('SHOW_IN_SUBNAME_MODEL', True))
@@ -1846,6 +1847,9 @@ def should_skip_file(file_path: str, target_language: LanguageCode, audio_langs=
 def get_subtitle_languages(video_path):
     """
     Extract language codes from each subtitle stream in the video file using pyav.
+    Forced subtitle tracks are excluded when ignore_forced_subtitles is enabled,
+    because a forced track only covers a small portion of dialogue and should not
+    be treated as full subtitle coverage.
     :param video_path: Path to the video file
     :return: List of language codes for each subtitle stream
     """
@@ -1854,6 +1858,9 @@ def get_subtitle_languages(video_path):
     try:
         with av.open(video_path) as container:
             for stream in container.streams.subtitles:
+                if ignore_forced_subtitles and 'forced' in stream.disposition:
+                    logging.debug(f"Skipping forced subtitle stream (language={stream.metadata.get('language', 'unknown')}) in {video_path}")
+                    continue
                 lang_code = stream.metadata.get('language')
                 if lang_code:
                     languages.append(LanguageCode.from_iso_639_2(lang_code))
@@ -1893,6 +1900,9 @@ def subtitle_exists_in_language(video_file, target_language: LanguageCode):
 def has_internal_subtitle_in_language(video_file: str, target_language: LanguageCode) -> bool:
     """
     Checks whether a video container has an embedded subtitle track in the given language.
+    Forced subtitle tracks are excluded when ignore_forced_subtitles is enabled,
+    because a forced track only covers a small portion of dialogue and should not
+    be treated as full subtitle coverage.
 
     Args:
         video_file: Path to the video file.
@@ -1905,6 +1915,9 @@ def has_internal_subtitle_in_language(video_file: str, target_language: Language
         with av.open(video_file) as container:
             for stream in container.streams:
                 if stream.type == 'subtitle' and 'language' in stream.metadata:
+                    if ignore_forced_subtitles and 'forced' in stream.disposition:
+                        logging.debug(f"Skipping forced subtitle stream (language={stream.metadata.get('language', 'unknown')}) in {video_file}")
+                        continue
                     stream_language = LanguageCode.from_string(stream.metadata.get('language', '').lower())
                     if stream_language == target_language:
                         return True


### PR DESCRIPTION
## Summary

Files with only a **forced** embedded subtitle track were being skipped as if they had full subtitle coverage. Forced tracks cover only a small slice of dialogue (usually foreign-language inserts) — they should never count as complete coverage.

## Root cause

Both `has_internal_subtitle_in_language()` and `get_subtitle_languages()` checked subtitle stream language but never inspected the `forced` disposition flag. PyAV exposes this cleanly via `'forced' in stream.disposition`.

## Changes

- **`subgen.py`** — both subtitle-checking functions now skip streams with the forced disposition when `IGNORE_FORCED_SUBTITLES=True`
- **`README.md`** — update note + new env var documented in the skip logic table

## New environment variable

| Variable | Default | Description |
|---|---|---|
| `IGNORE_FORCED_SUBTITLES` | `True` | Excludes forced subtitle tracks from skip-coverage checks. Files whose only matching tracks are forced are transcribed normally. Set `False` to restore old behaviour. |

## Test plan

- [x] 113/113 non-endpoint tests pass
- [ ] Test with a file that has only a forced English subtitle track — should now be transcribed instead of skipped
- [ ] Test with a file that has a full English subtitle track — should still be skipped as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)