### PR TITLE
fix: condition_on_previous_text=False — stop early transcription cutoff

### DIFF
--- a/subgen.py
+++ b/subgen.py
@@ -1054,6 +1054,7 @@ def asr_task_worker(task_data: dict) -> None:
             language=language or None,
             word_timestamps=True,
             vad_filter=vad_filter,
+            condition_on_previous_text=False,
             **fw_kwargs,
         )
         display_name = os.path.basename(video_file) if video_file else task_id
@@ -1541,6 +1542,7 @@ def gen_subtitles(file_path: str, transcription_type: str, force_language: Langu
             task=transcription_type,
             word_timestamps=True,
             vad_filter=vad_filter,
+            condition_on_previous_text=False,
             **fw_kwargs,
         )
         display_name = os.path.basename(file_path)


### PR DESCRIPTION
## Summary

- Sets `condition_on_previous_text=False` on both `model.transcribe()` calls (`gen_subtitles` and `asr_task_worker`)

## Problem

Transcription was stopping partway through files — confirmed on Bluey S01E01 which cut off at 2:43 of a 7:17 episode. Root cause:

faster-whisper defaults `condition_on_previous_text=True`, meaning each 30-second Whisper chunk is prompted with the decoded text from the previous chunk. When a music or noisy section causes a hallucination (e.g. the `. .` segments seen in the SRT), the next chunk is conditioned on that garbage → more hallucinations → hits the internal compression ratio threshold → Whisper stops transcribing the rest of the file.

## Fix

`condition_on_previous_text=False` decodes each chunk independently. A bad music/noise segment stays isolated and cannot cascade into stopping the whole file.

stable-ts was applying this workaround automatically behind the scenes. Since we now call faster-whisper directly, we set it explicitly.

Users who need the old behaviour can override per-container with `SUBGEN_KWARGS={"condition_on_previous_text": true}`.

## Test plan

- [ ] Re-run Bluey S01E01 — transcription should cover the full 7:17 instead of stopping at 2:43
- [ ] Verify no regression on files that were already transcribing correctly
- [ ] 138/138 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)