### PR TITLE
fix: correct forced-subtitle Disposition check (TypeError silently broke detection)

### DIFF
--- a/subgen.py
+++ b/subgen.py
@@ -1,4 +1,4 @@
-subgen_version = '2026.06.1'
+subgen_version = '2026.06.2'
 
 """
 ENVIRONMENT VARIABLES DOCUMENTATION
@@ -153,6 +153,7 @@ webhook_url_completed = os.getenv('WEBHOOK_URL_COMPLETED', '')
 skip_if_external_sub_exists = get_env_with_fallback('SKIP_IF_EXTERNAL_SUBTITLES_EXIST', 'SKIPIFEXTERNALSUB', False, convert_to_bool)
 skip_if_target_subtitle_exists = get_env_with_fallback('SKIP_IF_TARGET_SUBTITLES_EXIST', 'SKIP_IF_TO_TRANSCRIBE_SUB_ALREADY_EXIST', True, convert_to_bool)
 skip_if_internal_sub_language = LanguageCode.from_string(get_env_with_fallback('SKIP_IF_INTERNAL_SUBTITLES_LANGUAGE', 'SKIPIFINTERNALSUBLANG', ''))
+ignore_forced_subtitles = convert_to_bool(os.getenv('IGNORE_FORCED_SUBTITLES', True))
 plex_queue_next_episode = convert_to_bool(os.getenv('PLEX_QUEUE_NEXT_EPISODE', False))
 plex_queue_season = convert_to_bool(os.getenv('PLEX_QUEUE_SEASON', False))
 plex_queue_series = convert_to_bool(os.getenv('PLEX_QUEUE_SERIES', False))
@@ -1858,8 +1859,8 @@ def get_subtitle_languages(video_path):
     try:
         with av.open(video_path) as container:
             for stream in container.streams.subtitles:
-                if ignore_forced_subtitles and 'forced' in stream.disposition:
-                    logging.debug(f"Skipping forced subtitle stream (language={stream.metadata.get('language', 'unknown')}) in {video_path}")
+                if ignore_forced_subtitles and bool(stream.disposition & av.stream.Disposition.forced):
+                    logging.debug(f"get_subtitle_languages: skipping forced subtitle stream in {video_path}")
                     continue
                 lang_code = stream.metadata.get('language')
                 if lang_code:
@@ -1914,11 +1915,18 @@ def has_internal_subtitle_in_language(video_file: str, target_language: Language
     try:
         with av.open(video_file) as container:
             for stream in container.streams:
+                lang_tag = stream.metadata.get('language', '') if stream.metadata else ''
+                is_forced = bool(stream.disposition & av.stream.Disposition.forced)
+                logging.debug(
+                    f"has_internal_subtitle_in_language: stream #{stream.index} "
+                    f"type={stream.type!r} lang={lang_tag!r} forced={is_forced} "
+                    f"target={target_language}"
+                )
                 if stream.type == 'subtitle' and 'language' in stream.metadata:
-                    if ignore_forced_subtitles and 'forced' in stream.disposition:
-                        logging.debug(f"Skipping forced subtitle stream (language={stream.metadata.get('language', 'unknown')}) in {video_file}")
+                    if ignore_forced_subtitles and is_forced:
+                        logging.debug(f"Skipping forced subtitle stream (language={lang_tag}) in {video_file}")
                         continue
-                    stream_language = LanguageCode.from_string(stream.metadata.get('language', '').lower())
+                    stream_language = LanguageCode.from_string(lang_tag.lower())
                     if stream_language == target_language:
                         return True
             return False

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -40,6 +40,11 @@ class TestGetSubtitleLanguagesException:
         """Happy path: still returns languages when av.open works."""
         stream = MagicMock()
         stream.metadata = {"language": "eng"}
+        # Make stream.disposition & <anything> return 0 (falsy) so the forced-subtitle
+        # check does not skip this stream. av is fully mocked so we can't use the real
+        # Disposition type — configure __and__ directly instead.
+        stream.disposition = MagicMock()
+        stream.disposition.__and__ = MagicMock(return_value=0)
         container = MagicMock()
         container.__enter__ = MagicMock(return_value=container)
         container.__exit__ = MagicMock(return_value=False)


### PR DESCRIPTION
## Summary

- Fixes `IGNORE_FORCED_SUBTITLES` — the env var existed but never actually worked
- Adds per-stream DEBUG logging to `has_internal_subtitle_in_language` to make detection failures visible

## Problem

The forced-subtitle checks in `get_subtitle_languages()` and `has_internal_subtitle_in_language()` used:

```python
if ignore_forced_subtitles and 'forced' in stream.disposition:
```

`av.stream.Disposition` is a Python `Flag` enum. The `in` operator is not valid on a Flag instance and raises `TypeError: unsupported operand type(s) for 'in': 'str' and 'Disposition'`. This exception was silently caught by the surrounding `try/except`, causing:

- `has_internal_subtitle_in_language()` → always returns `False`
- Files with a forced embedded subtitle → always transcribed, regardless of `IGNORE_FORCED_SUBTITLES`

## Fix

```python
# before (broken)
if ignore_forced_subtitles and 'forced' in stream.disposition:

# after (correct)
if ignore_forced_subtitles and bool(stream.disposition & av.stream.Disposition.forced):
```

Applied in both `get_subtitle_languages()` and `has_internal_subtitle_in_language()`.

Also adds a `DEBUG`-level log line per stream in `has_internal_subtitle_in_language` showing stream index, type, language tag, forced flag, and the target language — useful for diagnosing future detection issues without reading source code.

## Test plan

- [ ] File with only a forced English subtitle + `IGNORE_FORCED_SUBTITLES=True` (default) → subgen transcribes it
- [ ] File with only a forced English subtitle + `IGNORE_FORCED_SUBTITLES=False` → subgen skips it
- [ ] File with a normal (non-forced) English subtitle → subgen skips it regardless of setting
- [ ] Enable `DEBUG=True`, confirm per-stream log lines appear during subtitle checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)