### PR TITLE
fix: update CUDA base to 12.8.1 and torch to cu128 for Blackwell GPU support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.3.2-base-ubuntu22.04
+FROM nvidia/cuda:12.8.1-base-ubuntu22.04
 
 # Apt packages — own layer so pip changes don't re-run apt
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -8,7 +8,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # Torch — large and rarely changes; own layer so requirements.txt changes don't bust it
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install -U torch torchaudio --index-url https://download.pytorch.org/whl/cu124
+    python3 -m pip install -U torch torchaudio --index-url https://download.pytorch.org/whl/cu128
 
 # App dependencies — only rebuilds when requirements.txt changes
 COPY requirements.txt /


### PR DESCRIPTION
## Summary

- Bumps CUDA base image from `nvidia/cuda:12.3.2-base-ubuntu22.04` → `nvidia/cuda:12.8.1-base-ubuntu22.04`
- Bumps PyTorch install index from `cu124` → `cu128`

## Why

CUDA 12.3 predates the Blackwell architecture (RTX 5000 series, RTX Pro 2000 — sm_120). Users on these GPUs see `CUBLAS_STATUS_NOT_SUPPORTED` with the default compute type because the cuBLAS bundled in the 12.3 image has no sm_120 codepath. They can work around it by setting `WHISPER_COMPUTE_TYPE=float16`, but even then they don't get proper Tensor Core utilisation and performance is degraded.

CUDA 12.8 was the first release with full Blackwell support. Bumping both the base image and the torch index URL ensures the cuBLAS used by CTranslate2 (via faster-whisper) and PyTorch are both Blackwell-aware.

## Test plan

- [ ] Rebuild GPU image on a Blackwell machine and confirm default `compute_type=auto` resolves to `int8_float16` without error
- [ ] Existing NVIDIA (non-Blackwell) hardware unaffected — CUDA 12.8 is backward-compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)