### PR TITLE
feat: skip directories containing a .subgen_skip marker file

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Create two separate Webhooks in Tautulli pointing to `http://<your-ip>:9000/taut
 | `PROCESS_MEDIA_ON_PLAY` | `True` | Generate subs for media when it is played (when triggered by webhook). |
 | `TRANSCRIBE_FOLDERS` | `''` | Pipe-separated list (e.g., `/tv&#124;/movies`) to recurse through and queue existing media. |
 | `MONITOR` | `False` | Actively watches `TRANSCRIBE_FOLDERS` in real-time for newly pasted files. |
+| `SKIP_STARTUP_SCAN` | `False` | Skips the startup scan of `TRANSCRIBE_FOLDERS` entirely. Subgen will still watch for new files if `MONITOR` is enabled, but won't iterate existing files on start. Useful if your library is already subtitled and you only want to catch newly added files. |
 | `PLEX_QUEUE_NEXT_EPISODE` | `False` | Auto-queues the *next* Plex episode when Subgen is triggered. |
 | `PLEX_QUEUE_SEASON` | `False` | Auto-queues the *entire remaining season* when Subgen is triggered. |
 | `PLEX_QUEUE_SERIES` | `False` | Auto-queues the *entire remaining series* when Subgen is triggered. |
@@ -250,6 +251,13 @@ Create two separate Webhooks in Tautulli pointing to `http://<your-ip>:9000/taut
 
 ### ⏭️ Skip Logic & Audio Targeting
 *Prevent Subgen from wasting time on files that don't need subtitles.*
+
+**Directory skip marker:** Place an empty `.subgen_skip` file in any directory to tell Subgen to skip that directory and all of its subdirectories — both during the startup scan and when watching for new files. Useful for completed shows or any section of your library that will never need new subtitles.
+```bash
+touch "/tv/The Simpsons/.subgen_skip"   # skips all seasons
+touch "/tv/Some Show/Season 1/.subgen_skip"  # skips just that season
+```
+
 | Variable | Default | Description |
 |---|---|---|
 | `SKIP_IF_TARGET_SUBTITLES_EXIST` | `True` | Skips if an auto-generated subtitle in your desired language already exists. |

--- a/subgen.py
+++ b/subgen.py
@@ -2471,12 +2471,30 @@ def is_file_stable(file_path, wait_time=2, check_intervals=3):
 
     return False  # File is still changing
 
+SKIP_MARKER = ".subgen_skip"
+
+
+def _is_in_skipped_dir(file_path: str) -> bool:
+    """Return True if any ancestor directory of file_path contains a .subgen_skip marker."""
+    check = os.path.dirname(os.path.abspath(file_path))
+    while True:
+        if os.path.exists(os.path.join(check, SKIP_MARKER)):
+            return True
+        parent = os.path.dirname(check)
+        if parent == check:
+            return False
+        check = parent
+
+
 class NewFileHandler(FileSystemEventHandler):
     """Watchdog handler that queues newly created or modified media files."""
 
     def create_subtitle(self, event):
         if not event.is_directory:
             file_path = event.src_path
+            if _is_in_skipped_dir(file_path):
+                logging.info(f"Skipping (skip marker present): {file_path}")
+                return
             if has_audio(file_path):
                 logging.info(f"File: {path_mapping(file_path)} was added")
                 gen_subtitles_queue(path_mapping(file_path), transcribe_or_translate)
@@ -2501,6 +2519,10 @@ def transcribe_existing(transcribe_folders, forceLanguage: LanguageCode = Langua
     for path in transcribe_folders:
         logging.debug(path)
         for root, dirs, files in os.walk(path):
+            if SKIP_MARKER in files:
+                logging.info(f"Skipping (skip marker present): {root}")
+                dirs.clear()
+                continue
             for file in files:
                 file_path = os.path.join(root, file)
                 gen_subtitles_queue(path_mapping(file_path), transcribe_or_translate, forceLanguage)

--- a/subgen.py
+++ b/subgen.py
@@ -135,6 +135,7 @@ path_mapping_from = os.getenv('PATH_MAPPING_FROM', r'/tv')
 path_mapping_to = os.getenv('PATH_MAPPING_TO', r'/Volumes/TV')
 model_location = os.getenv('MODEL_PATH', './models')
 monitor = convert_to_bool(os.getenv('MONITOR', False))
+skip_startup_scan = convert_to_bool(os.getenv('SKIP_STARTUP_SCAN', False))
 transcribe_folders = os.getenv('TRANSCRIBE_FOLDERS', '')
 transcribe_or_translate = os.getenv('TRANSCRIBE_OR_TRANSLATE', 'transcribe').lower()
 clear_vram_on_complete = convert_to_bool(os.getenv('CLEAR_VRAM_ON_COMPLETE', True))
@@ -2514,22 +2515,25 @@ class NewFileHandler(FileSystemEventHandler):
 
 def transcribe_existing(transcribe_folders, forceLanguage: LanguageCode = LanguageCode.NONE):
     transcribe_folders = transcribe_folders.split("|")
-    logging.info("Starting to search folders to see if we need to create subtitles.")
-    logging.debug("The folders are:")
-    for path in transcribe_folders:
-        logging.debug(path)
-        for root, dirs, files in os.walk(path):
-            if SKIP_MARKER in files:
-                logging.info(f"Skipping (skip marker present): {root}")
-                dirs.clear()
-                continue
-            for file in files:
-                file_path = os.path.join(root, file)
-                gen_subtitles_queue(path_mapping(file_path), transcribe_or_translate, forceLanguage)
-        # if the path specified was actually a single file and not a folder, process it
-        if os.path.isfile(path):
-            if has_audio(path):
-                gen_subtitles_queue(path_mapping(path), transcribe_or_translate, forceLanguage)
+    if skip_startup_scan:
+        logging.info("SKIP_STARTUP_SCAN is enabled — skipping existing file scan.")
+    else:
+        logging.info("Starting to search folders to see if we need to create subtitles.")
+        logging.debug("The folders are:")
+        for path in transcribe_folders:
+            logging.debug(path)
+            for root, dirs, files in os.walk(path):
+                if SKIP_MARKER in files:
+                    logging.info(f"Skipping (skip marker present): {root}")
+                    dirs.clear()
+                    continue
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    gen_subtitles_queue(path_mapping(file_path), transcribe_or_translate, forceLanguage)
+            # if the path specified was actually a single file and not a folder, process it
+            if os.path.isfile(path):
+                if has_audio(path):
+                    gen_subtitles_queue(path_mapping(path), transcribe_or_translate, forceLanguage)
     # Set up the observer to watch for new files
     if monitor:
         observer = Observer()


### PR DESCRIPTION
## Summary

- Adds a `.subgen_skip` marker file: place it in any directory to prevent subgen from scanning it (and all subdirectories) during startup and from queuing new files detected by the file watcher
- Adds `SKIP_STARTUP_SCAN` env var: skips the startup folder scan entirely while still enabling the `MONITOR` file watcher for new files

## Details

### `.subgen_skip` marker
Place an empty `.subgen_skip` file in any directory — subgen skips that directory and all subdirectories recursively, both on startup and in the live file watcher.

```bash
# Skip an entire show (all seasons)
touch "/tv/The Simpsons/.subgen_skip"

# Skip a single season
touch "/tv/Some Show/Season 1/.subgen_skip"
```

### `SKIP_STARTUP_SCAN`
Set `SKIP_STARTUP_SCAN=true` to skip the startup iteration of `TRANSCRIBE_FOLDERS` entirely. Subgen will still watch for newly added files if `MONITOR` is enabled. Useful if your library is already subtitled and you only want to catch new files without waiting through a full scan on every restart.

## Test plan

- [ ] Restart subgen with a `.subgen_skip` file in a subdirectory — confirm that directory and its children are not scanned
- [ ] Drop a new media file into a skipped directory — confirm it is not queued by the file watcher
- [ ] Set `SKIP_STARTUP_SCAN=true` with `MONITOR=true` — confirm no startup scan occurs but new files are still picked up
- [ ] Confirm directories without the marker file scan normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)