### PR TITLE
fix: don't skip when SUBTITLE_LANGUAGE_NAME set but audio language unknown

### DIFF
--- a/subgen.py
+++ b/subgen.py
@@ -1973,16 +1973,21 @@ def should_skip_file(file_path: str, target_language: LanguageCode, audio_langs=
 
     # 4. Skip if a subtitle already exists in the target language.
     if skip_if_target_subtitle_exists:
-        if subtitle_exists_in_language(file_path, target_language):
-            if target_language == LanguageCode.NONE:
-                logging.info(f"Skipping {base_name}: Subtitles already exist and audio language could not be detected from file metadata.")
-            else:
-                lang_name = target_language.to_name()
-                logging.info(f"Skipping {base_name}: Subtitles already exist in {lang_name}.")
-            return True
+        # When audio language is unknown but SUBTITLE_LANGUAGE_NAME is explicitly set, we know
+        # exactly what file we intend to write — skip the generic "any subtitle → skip" check
+        # and only look for the specifically named output below.
+        named_output_configured = subtitle_language_name and LanguageCode.is_valid_language(subtitle_language_name)
+        if not (target_language == LanguageCode.NONE and named_output_configured):
+            if subtitle_exists_in_language(file_path, target_language):
+                if target_language == LanguageCode.NONE:
+                    logging.info(f"Skipping {base_name}: Subtitles already exist and audio language could not be detected from file metadata.")
+                else:
+                    lang_name = target_language.to_name()
+                    logging.info(f"Skipping {base_name}: Subtitles already exist in {lang_name}.")
+                return True
 
         # Since SUBTITLE_LANGUAGE_NAME overrides the output filename, check if it exists in the folder.
-        if subtitle_language_name and LanguageCode.is_valid_language(subtitle_language_name):
+        if named_output_configured:
             external_lang = LanguageCode.from_string(subtitle_language_name)
             if has_external_subtitle_in_language(file_path, external_lang, recursion=True, only_match_subgen_subtitles=only_match_subgen_subtitles):
                 logging.info(f"Skipping {base_name}: Subtitles already exist in custom name '{subtitle_language_name}'.")


### PR DESCRIPTION
Fixes #337

## Root cause

When a file's audio track has no language metadata and `SHOULD_WHISPER_DETECT_AUDIO_LANGUAGE=false`, `target_language` is `LanguageCode.NONE`. The skip check at that point calls `subtitle_exists_in_language(file_path, NONE)`, which has explicit logic to return `True` for **any** subtitle found when the language is unknown. This caused subgen to skip and log _"Subtitles already exist and audio language could not be detected from file metadata"_ before ever reaching the `SUBTITLE_LANGUAGE_NAME`-specific check.

So a file like:
```
S01E01.mkv          (no audio language tag)
S01E01.en.cc.srt    (pre-existing, not the target)
```
with `SUBTITLE_LANGUAGE_NAME=aa` would be incorrectly skipped, even though `S01E01.aa.srt` didn't exist.

## Fix

When `target_language == NONE` **and** `SUBTITLE_LANGUAGE_NAME` is explicitly configured, bypass the generic subtitle existence check and let only the named-output check determine whether to skip. The generic check is only meaningful when we know the target language; when we don't but have an explicit output name, the named-output check is the right gate.

No behaviour change for users who don't have `SUBTITLE_LANGUAGE_NAME` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)