### PR TITLE
fix: SKIP_ONLY_SUBGEN_SUBTITLES now ignores embedded subtitle streams

### DIFF
--- a/subgen.py
+++ b/subgen.py
@@ -2070,7 +2070,11 @@ def subtitle_exists_in_language(video_file, target_language: LanguageCode):
     Returns:
         bool: True if a subtitle file with the target language is found, False otherwise.
     """
-    return has_internal_subtitle_in_language(video_file, target_language) or has_external_subtitle_in_language(video_file, target_language, recursion=True, only_match_subgen_subtitles=only_match_subgen_subtitles)
+    # Embedded tracks can never be subgen-created files, so when only_match_subgen_subtitles
+    # is set, internal subtitle streams should not count as coverage.
+    internal = (not only_match_subgen_subtitles) and has_internal_subtitle_in_language(video_file, target_language)
+    external = has_external_subtitle_in_language(video_file, target_language, recursion=True, only_match_subgen_subtitles=only_match_subgen_subtitles)
+    return internal or external
 
 def has_internal_subtitle_in_language(video_file: str, target_language: LanguageCode) -> bool:
     """


### PR DESCRIPTION
Fixes #339

## Root cause

`subtitle_exists_in_language` calls `has_internal_subtitle_in_language` unconditionally, then passes `only_match_subgen_subtitles` only to the external file check. Since embedded subtitle tracks can never be subgen-created files, the flag had no effect on the internal check — a file with embedded English subtitles would still be skipped even with `SKIP_ONLY_SUBGEN_SUBTITLES=True`.

## Fix

When `SKIP_ONLY_SUBGEN_SUBTITLES=True`, skip the internal subtitle check entirely. Embedded tracks are by definition not subgen-generated, so they should not count as coverage when the user has said "only skip for subgen files."

## Impact

- `SKIP_ONLY_SUBGEN_SUBTITLES=False` (default): no behaviour change
- `SKIP_ONLY_SUBGEN_SUBTITLES=True`: embedded subtitle streams no longer trigger a skip; only external `*.subgen.*` files do

The separate `SKIP_IF_INTERNAL_SUBTITLES_LANGUAGE` check (check 5a) is unaffected — that's a distinct opt-in skip for a specific embedded language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)