### PR TITLE
fix: move SKIP_STARTUP_SCAN check to lifespan call site, not transcri…

### DIFF
--- a/subgen.py
+++ b/subgen.py
@@ -209,7 +209,10 @@ AUDIO_EXTENSIONS = (
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     if transcribe_folders:
-        threading.Thread(target=transcribe_existing, args=(transcribe_folders,), daemon=True).start()
+        if skip_startup_scan:
+            logging.info("SKIP_STARTUP_SCAN is enabled — skipping the startup scan of existing files.")
+        else:
+            threading.Thread(target=transcribe_existing, args=(transcribe_folders,), daemon=True).start()
     yield
 
 app = FastAPI(lifespan=lifespan)
@@ -2515,25 +2518,22 @@ class NewFileHandler(FileSystemEventHandler):
 
 def transcribe_existing(transcribe_folders, forceLanguage: LanguageCode = LanguageCode.NONE):
     transcribe_folders = transcribe_folders.split("|")
-    if skip_startup_scan:
-        logging.info("SKIP_STARTUP_SCAN is enabled — skipping existing file scan.")
-    else:
-        logging.info("Starting to search folders to see if we need to create subtitles.")
-        logging.debug("The folders are:")
-        for path in transcribe_folders:
-            logging.debug(path)
-            for root, dirs, files in os.walk(path):
-                if SKIP_MARKER in files:
-                    logging.info(f"Skipping (skip marker present): {root}")
-                    dirs.clear()
-                    continue
-                for file in files:
-                    file_path = os.path.join(root, file)
-                    gen_subtitles_queue(path_mapping(file_path), transcribe_or_translate, forceLanguage)
-            # if the path specified was actually a single file and not a folder, process it
-            if os.path.isfile(path):
-                if has_audio(path):
-                    gen_subtitles_queue(path_mapping(path), transcribe_or_translate, forceLanguage)
+    logging.info("Starting to search folders to see if we need to create subtitles.")
+    logging.debug("The folders are:")
+    for path in transcribe_folders:
+        logging.debug(path)
+        for root, dirs, files in os.walk(path):
+            if SKIP_MARKER in files:
+                logging.info(f"Skipping (skip marker present): {root}")
+                dirs.clear()
+                continue
+            for file in files:
+                file_path = os.path.join(root, file)
+                gen_subtitles_queue(path_mapping(file_path), transcribe_or_translate, forceLanguage)
+        # if the path specified was actually a single file and not a folder, process it
+        if os.path.isfile(path):
+            if has_audio(path):
+                gen_subtitles_queue(path_mapping(path), transcribe_or_translate, forceLanguage)
     # Set up the observer to watch for new files
     if monitor:
         observer = Observer()

--- a/tests/test_skip_logic.py
+++ b/tests/test_skip_logic.py
@@ -285,32 +285,25 @@ class TestSubgenSkipMarker:
 
 
 # ---------------------------------------------------------------------------
-# SKIP_STARTUP_SCAN — transcribe_existing() scan bypass
+# SKIP_STARTUP_SCAN — lifespan call-site gate (must NOT affect /batch)
 # ---------------------------------------------------------------------------
 class TestSkipStartupScan:
+    """
+    SKIP_STARTUP_SCAN gates the lifespan call site, not transcribe_existing()
+    itself, so /batch (which also calls transcribe_existing) is unaffected.
+    """
+
     def _patch_scan_defaults(self, monkeypatch):
         monkeypatch.setattr(subgen, "monitor", False)
         monkeypatch.setattr(subgen, "use_path_mapping", False)
         monkeypatch.setattr(subgen, "transcribe_or_translate", "transcribe")
 
-    def test_skip_startup_scan_queues_nothing(self, monkeypatch, tmp_path):
-        """With SKIP_STARTUP_SCAN=True, no existing files are queued on startup."""
+    def test_transcribe_existing_still_works_when_skip_enabled(self, monkeypatch, tmp_path):
+        """transcribe_existing() must queue files regardless of skip_startup_scan.
+        The flag is checked at the lifespan call site, not inside this function,
+        so /batch calls are never silenced by it."""
         self._patch_scan_defaults(monkeypatch)
         monkeypatch.setattr(subgen, "skip_startup_scan", True)
-
-        (tmp_path / "movie.mkv").touch()
-
-        queued = []
-        monkeypatch.setattr(subgen, "gen_subtitles_queue", lambda p, t, fl: queued.append(p))
-
-        subgen.transcribe_existing(str(tmp_path))
-
-        assert queued == [], "SKIP_STARTUP_SCAN=True must not queue any existing files"
-
-    def test_skip_startup_scan_false_scans_normally(self, monkeypatch, tmp_path):
-        """With SKIP_STARTUP_SCAN=False (default), existing files are still queued."""
-        self._patch_scan_defaults(monkeypatch)
-        monkeypatch.setattr(subgen, "skip_startup_scan", False)
 
         video = tmp_path / "movie.mkv"
         video.touch()
@@ -320,4 +313,60 @@ class TestSkipStartupScan:
 
         subgen.transcribe_existing(str(tmp_path))
 
-        assert str(video) in queued
+        assert str(video) in queued, (
+            "transcribe_existing() must not be affected by skip_startup_scan — "
+            "the flag belongs at the lifespan call site so /batch still works"
+        )
+
+    def test_lifespan_skips_thread_when_skip_enabled(self, monkeypatch, tmp_path):
+        """With SKIP_STARTUP_SCAN=True, lifespan must not spawn the scan thread."""
+        monkeypatch.setattr(subgen, "transcribe_folders", str(tmp_path))
+        monkeypatch.setattr(subgen, "skip_startup_scan", True)
+
+        spawned = []
+        monkeypatch.setattr(subgen, "transcribe_existing", lambda *a, **k: spawned.append(a))
+
+        import threading as _threading
+        original_thread = _threading.Thread
+
+        threads_started = []
+
+        def fake_thread(*args, **kwargs):
+            t = original_thread(*args, **kwargs)
+            threads_started.append(kwargs.get("target") or args[0])
+            return t
+
+        with patch("subgen.threading.Thread", side_effect=fake_thread):
+            import asyncio
+            async def run():
+                async with subgen.lifespan(subgen.app):
+                    pass
+            asyncio.run(run())
+
+        assert subgen.transcribe_existing not in [fn for fn in threads_started], (
+            "lifespan must not start the scan thread when SKIP_STARTUP_SCAN=True"
+        )
+
+    def test_lifespan_starts_thread_when_skip_disabled(self, monkeypatch, tmp_path):
+        """With SKIP_STARTUP_SCAN=False, lifespan must spawn the scan thread."""
+        monkeypatch.setattr(subgen, "transcribe_folders", str(tmp_path))
+        monkeypatch.setattr(subgen, "skip_startup_scan", False)
+
+        threads_started = []
+
+        def fake_thread(*args, **kwargs):
+            threads_started.append(kwargs.get("target"))
+            m = MagicMock()
+            m.start = MagicMock()
+            return m
+
+        with patch("subgen.threading.Thread", side_effect=fake_thread):
+            import asyncio
+            async def run():
+                async with subgen.lifespan(subgen.app):
+                    pass
+            asyncio.run(run())
+
+        assert subgen.transcribe_existing in threads_started, (
+            "lifespan must start the scan thread when SKIP_STARTUP_SCAN=False"
+        )


### PR DESCRIPTION
…be_existing

Gating the flag inside transcribe_existing() silently broke POST /batch since both lifespan and /batch call the same function. Moving the check to the lifespan call site means /batch is unaffected regardless of the flag value.

Updated tests to assert the correct semantics: transcribe_existing() works normally even when skip_startup_scan=True, and lifespan is the gate.

Fixes #345